### PR TITLE
Support prefixed syms in clojure-indent-function

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -685,7 +685,8 @@ This function also returns nil meaning don't specify the indentation."
              (function-tail (first
                              (last
                               (split-string (substring-no-properties function) "/")))))
-        (setq method (get (intern-soft function-tail) 'clojure-indent-function))
+        (setq method (or (get (intern-soft function) 'clojure-indent-function)                                                                                                                                      
+                         (get (intern-soft function-tail) 'clojure-indent-function)))                                                                                                                               
         (cond ((member (char-after open-paren) '(?\[ ?\{))
                (goto-char open-paren)
                (1+ (current-column)))


### PR DESCRIPTION
When a Clojure lib uses the same var name as clojure.core, it may prefer different indent rules. This change allows specific prefixed symbols to override the indent rule of the unprefixed symbol.
